### PR TITLE
Swap all remaining vanilla weapon_type references in bmod equipment to W_ENERGY01

### DIFF
--- a/DATA/EQUIPMENT/BMOD/bmod_equip_aux.ini
+++ b/DATA/EQUIPMENT/BMOD/bmod_equip_aux.ini
@@ -304,7 +304,7 @@
     hit_pts = 2
     hull_damage = 90.9
     energy_damage = 66
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = fire_ac2_01
     munition_hit_effect = bmod_ac2_impact
     const_effect = bmod_mg_01_proj
@@ -355,7 +355,7 @@
     hit_pts = 2
     hull_damage = 1000
     energy_damage = 1250
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = bmod_s_laser
     munition_hit_effect = bmod_small_laser_impact
     const_effect = bmod_small_laser_proj
@@ -402,7 +402,7 @@
     hit_pts = 2
     hull_damage = 1500
     energy_damage = 1875
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = bmod_m_laser
     munition_hit_effect = bmod_medium_laser_impact
     const_effect = bmod_medium_laser_proj
@@ -449,7 +449,7 @@
     hit_pts = 2
     hull_damage = 2470.42
     energy_damage = 3088
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = bmod_l_laser
     munition_hit_effect = bmod_large_laser_impact
     const_effect = bmod_large_laser_proj
@@ -496,7 +496,7 @@
     hit_pts = 2
     hull_damage = 4929
     energy_damage = 4929
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = bmod_ppc
     munition_hit_effect = bmod_ppc_impact
     const_effect = bmod_ppc_projectile
@@ -544,7 +544,7 @@
     hit_pts = 2
     hull_damage = 5200
     energy_damage = 3300
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = bmod_jnk_bolt
     munition_hit_effect = bmod_jnk_energy_impact
     const_effect = bmod_jnk_energy_beam
@@ -1034,7 +1034,7 @@
     hp_type = hp_gun
     requires_ammo = true
     hit_pts = 2
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = bmod_rocket
     detonation_dist = 5
     lifetime = 3
@@ -1110,7 +1110,7 @@
     hp_type = hp_gun
     requires_ammo = true
     hit_pts = 2
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = fire_torpedo
     detonation_dist = 5
     lifetime = 10
@@ -1172,7 +1172,7 @@
     hit_pts = 2
     hull_damage = 396
     energy_damage = 39.6
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = fire_ac10_01
     munition_hit_effect = bmod_ac10_impact
     const_effect = bmod_ac10_01_proj

--- a/DATA/EQUIPMENT/BMOD/bmod_equip_blaster.ini
+++ b/DATA/EQUIPMENT/BMOD/bmod_equip_blaster.ini
@@ -12,7 +12,7 @@
         hit_pts = 2
         hull_damage = 250.82
         energy_damage = 250.82
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = bmod_fire_mpulse01
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_02_projectile
@@ -59,7 +59,7 @@
         hit_pts = 2
         hull_damage = 250.82
         energy_damage = 250.82
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = bmod_fire_mpulse01
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_02_projectile
@@ -106,7 +106,7 @@
         hit_pts = 2
         hull_damage = 250.82
         energy_damage = 250.82
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = bmod_fire_mpulse01
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_02_projectile
@@ -153,7 +153,7 @@
         hit_pts = 2
         hull_damage = 501.65
         energy_damage = 501.65
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = bmod_fire_mpulse01
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_02_projectile
@@ -200,7 +200,7 @@
         hit_pts = 2
         hull_damage = 501.65
         energy_damage = 501.65
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = bmod_fire_mpulse01
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_02_projectile
@@ -247,7 +247,7 @@
         hit_pts = 2
         hull_damage = 501.65
         energy_damage = 501.65
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = bmod_fire_mpulse01
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_02_projectile
@@ -294,7 +294,7 @@
         hit_pts = 2
         hull_damage = 752.47
         energy_damage = 752.47
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = bmod_fire_mpulse01
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_02_projectile
@@ -341,7 +341,7 @@
         hit_pts = 2
         hull_damage = 752.47
         energy_damage = 752.47
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = bmod_fire_mpulse01
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_02_projectile
@@ -388,7 +388,7 @@
         hit_pts = 2
         hull_damage = 752.47
         energy_damage = 752.47
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = bmod_fire_mpulse01
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_02_projectile
@@ -436,7 +436,7 @@
         hit_pts = 2
         hull_damage = 360
         energy_damage = 360
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_fc_x_gun_heavy
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_01_projectile
@@ -483,7 +483,7 @@
         hit_pts = 2
         hull_damage = 360
         energy_damage = 360
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_fc_x_gun_heavy
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_01_projectile
@@ -530,7 +530,7 @@
         hit_pts = 2
         hull_damage = 360
         energy_damage = 360
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_fc_x_gun_heavy
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_01_projectile
@@ -577,7 +577,7 @@
         hit_pts = 2
         hull_damage = 720
         energy_damage = 720
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_fc_x_gun_heavy
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_01_projectile
@@ -624,7 +624,7 @@
         hit_pts = 2
         hull_damage = 720
         energy_damage = 720
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_fc_x_gun_heavy
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_01_projectile
@@ -671,7 +671,7 @@
         hit_pts = 2
         hull_damage = 720
         energy_damage = 720
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_fc_x_gun_heavy
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_01_projectile
@@ -718,7 +718,7 @@
         hit_pts = 2
         hull_damage = 1080
         energy_damage = 1080
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_fc_x_gun_heavy
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_01_projectile
@@ -765,7 +765,7 @@
         hit_pts = 2
         hull_damage = 1080
         energy_damage = 1080
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_fc_x_gun_heavy
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_01_projectile
@@ -812,7 +812,7 @@
         hit_pts = 2
         hull_damage = 1080
         energy_damage = 1080
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_fc_x_gun_heavy
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_01_projectile
@@ -861,7 +861,7 @@
         hit_pts = 2
         hull_damage = 124.84
         energy_damage = 124.84
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_photon5
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_li_n_light_blaster_01_projectile
@@ -908,7 +908,7 @@
         hit_pts = 2
         hull_damage = 124.84
         energy_damage = 124.84
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_photon5
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_li_n_light_blaster_01_projectile
@@ -955,7 +955,7 @@
         hit_pts = 2
         hull_damage = 124.84
         energy_damage = 124.84
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_photon5
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_li_n_light_blaster_01_projectile
@@ -1002,7 +1002,7 @@
         hit_pts = 2
         hull_damage = 249.69
         energy_damage = 249.69
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_photon5
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_li_n_light_blaster_01_projectile
@@ -1049,7 +1049,7 @@
         hit_pts = 2
         hull_damage = 249.69
         energy_damage = 249.69
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_photon5
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_li_n_light_blaster_01_projectile
@@ -1096,7 +1096,7 @@
         hit_pts = 2
         hull_damage = 249.69
         energy_damage = 249.69
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_photon5
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_li_n_light_blaster_01_projectile
@@ -1143,7 +1143,7 @@
         hit_pts = 2
         hull_damage = 374.54
         energy_damage = 374.54
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_photon5
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_li_n_light_blaster_01_projectile
@@ -1190,7 +1190,7 @@
         hit_pts = 2
         hull_damage = 374.54
         energy_damage = 374.54
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_photon5
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_li_n_light_blaster_01_projectile
@@ -1237,7 +1237,7 @@
         hit_pts = 2
         hull_damage = 374.54
         energy_damage = 374.54
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_photon5
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_li_n_light_blaster_01_projectile
@@ -1285,7 +1285,7 @@
         hit_pts = 2
         hull_damage = 220
         energy_damage = 220
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -1332,7 +1332,7 @@
         hit_pts = 2
         hull_damage = 220
         energy_damage = 220
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -1379,7 +1379,7 @@
         hit_pts = 2
         hull_damage = 220
         energy_damage = 220
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -1426,7 +1426,7 @@
         hit_pts = 2
         hull_damage = 440
         energy_damage = 440
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -1473,7 +1473,7 @@
         hit_pts = 2
         hull_damage = 440
         energy_damage = 440
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -1520,7 +1520,7 @@
         hit_pts = 2
         hull_damage = 440
         energy_damage = 440
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -1567,7 +1567,7 @@
         hit_pts = 2
         hull_damage = 660
         energy_damage = 660
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -1614,7 +1614,7 @@
         hit_pts = 2
         hull_damage = 660
         energy_damage = 660
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -1661,7 +1661,7 @@
         hit_pts = 2
         hull_damage = 660
         energy_damage = 660
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -1709,7 +1709,7 @@
         hit_pts = 2
         hull_damage = 400
         energy_damage = 400
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_li_n_plasma01
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_01_projectile
@@ -1756,7 +1756,7 @@
         hit_pts = 2
         hull_damage = 400
         energy_damage = 400
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_li_n_plasma01
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_01_projectile
@@ -1803,7 +1803,7 @@
         hit_pts = 2
         hull_damage = 400
         energy_damage = 400
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_li_n_plasma01
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_01_projectile
@@ -1850,7 +1850,7 @@
         hit_pts = 2
         hull_damage = 800
         energy_damage = 800
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_li_n_plasma01
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_01_projectile
@@ -1897,7 +1897,7 @@
         hit_pts = 2
         hull_damage = 800
         energy_damage = 800
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_li_n_plasma01
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_01_projectile
@@ -1944,7 +1944,7 @@
         hit_pts = 2
         hull_damage = 800
         energy_damage = 800
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_li_n_plasma01
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_01_projectile
@@ -1991,7 +1991,7 @@
         hit_pts = 2
         hull_damage = 1200
         energy_damage = 1200
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_li_n_plasma01
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_01_projectile
@@ -2038,7 +2038,7 @@
         hit_pts = 2
         hull_damage = 1200
         energy_damage = 1200
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_li_n_plasma01
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_01_projectile
@@ -2085,7 +2085,7 @@
         hit_pts = 2
         hull_damage = 1200
         energy_damage = 1200
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_li_n_plasma01
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_01_projectile
@@ -2134,7 +2134,7 @@
         hit_pts = 2
         hull_damage = 315
         energy_damage = 315
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_particle1
         munition_hit_effect = pi_particle_01_impact
         const_effect = pi_particle_01_proj
@@ -2181,7 +2181,7 @@
         hit_pts = 2
         hull_damage = 360
         energy_damage = 360
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_particle1
         munition_hit_effect = pi_particle_01_impact
         const_effect = pi_particle_01_proj
@@ -2228,7 +2228,7 @@
         hit_pts = 2
         hull_damage = 315
         energy_damage = 315
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_particle1
         munition_hit_effect = pi_particle_01_impact
         const_effect = pi_particle_01_proj
@@ -2275,7 +2275,7 @@
         hit_pts = 2
         hull_damage = 787.5
         energy_damage = 787.5
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_particle1
         munition_hit_effect = pi_particle_01_impact
         const_effect = pi_particle_01_proj
@@ -2322,7 +2322,7 @@
         hit_pts = 2
         hull_damage = 720
         energy_damage = 720
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_particle1
         munition_hit_effect = pi_particle_01_impact
         const_effect = pi_particle_01_proj
@@ -2369,7 +2369,7 @@
         hit_pts = 2
         hull_damage = 787.5
         energy_damage = 787.5
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_particle1
         munition_hit_effect = pi_particle_01_impact
         const_effect = pi_particle_01_proj
@@ -2416,7 +2416,7 @@
         hit_pts = 2
         hull_damage = 787.5
         energy_damage = 787.5
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_particle1
         munition_hit_effect = pi_particle_01_impact
         const_effect = pi_particle_01_proj
@@ -2463,7 +2463,7 @@
         hit_pts = 2
         hull_damage = 1080
         energy_damage = 1080
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_particle1
         munition_hit_effect = pi_particle_01_impact
         const_effect = pi_particle_01_proj
@@ -2510,7 +2510,7 @@
         hit_pts = 2
         hull_damage = 787.5
         energy_damage = 787.5
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_particle1
         munition_hit_effect = pi_particle_01_impact
         const_effect = pi_particle_01_proj
@@ -2558,7 +2558,7 @@
         hit_pts = 2
         hull_damage = 396.666
         energy_damage = 396.666
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser5
         munition_hit_effect = pi_laser_01_impact
         const_effect = pi_laser_01_proj
@@ -2605,7 +2605,7 @@
         hit_pts = 2
         hull_damage = 453.333
         energy_damage = 453.333
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser5
         munition_hit_effect = pi_laser_01_impact
         const_effect = pi_laser_01_proj
@@ -2652,7 +2652,7 @@
         hit_pts = 2
         hull_damage = 396.666
         energy_damage = 396.666
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser5
         munition_hit_effect = pi_laser_01_impact
         const_effect = pi_laser_01_proj
@@ -2699,7 +2699,7 @@
         hit_pts = 2
         hull_damage = 980
         energy_damage = 980
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser5
         munition_hit_effect = pi_laser_01_impact
         const_effect = pi_laser_01_proj
@@ -2746,7 +2746,7 @@
         hit_pts = 2
         hull_damage = 906.666
         energy_damage = 906.666
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser5
         munition_hit_effect = pi_laser_01_impact
         const_effect = pi_laser_01_proj
@@ -2793,7 +2793,7 @@
         hit_pts = 2
         hull_damage = 980
         energy_damage = 980
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser5
         munition_hit_effect = pi_laser_01_impact
         const_effect = pi_laser_01_proj
@@ -2840,7 +2840,7 @@
         hit_pts = 2
         hull_damage = 980
         energy_damage = 980
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser5
         munition_hit_effect = pi_laser_01_impact
         const_effect = pi_laser_01_proj
@@ -2887,7 +2887,7 @@
         hit_pts = 2
         hull_damage = 1360
         energy_damage = 1360
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser5
         munition_hit_effect = pi_laser_01_impact
         const_effect = pi_laser_01_proj
@@ -2934,7 +2934,7 @@
         hit_pts = 2
         hull_damage = 980
         energy_damage = 980
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser5
         munition_hit_effect = pi_laser_01_impact
         const_effect = pi_laser_01_proj
@@ -2982,7 +2982,7 @@
         hit_pts = 2
         hull_damage = 560
         energy_damage = 560
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -3029,7 +3029,7 @@
         hit_pts = 2
         hull_damage = 640
         energy_damage = 640
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -3076,7 +3076,7 @@
         hit_pts = 2
         hull_damage = 560
         energy_damage = 560
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -3123,7 +3123,7 @@
         hit_pts = 2
         hull_damage = 640
         energy_damage = 640
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -3170,7 +3170,7 @@
         hit_pts = 2
         hull_damage = 1280
         energy_damage = 1280
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -3217,7 +3217,7 @@
         hit_pts = 2
         hull_damage = 1920
         energy_damage = 1920
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -3265,7 +3265,7 @@
         hit_pts = 2
         hull_damage = 1260
         energy_damage = 1260
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -3312,7 +3312,7 @@
         hit_pts = 2
         hull_damage = 1280
         energy_damage = 1280
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -3359,7 +3359,7 @@
         hit_pts = 2
         hull_damage = 1260
         energy_damage = 1260
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -3406,7 +3406,7 @@
         hit_pts = 2
         hull_damage = 1260
         energy_damage = 1260
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -3453,7 +3453,7 @@
         hit_pts = 2
         hull_damage = 1920
         energy_damage = 1920
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -3500,7 +3500,7 @@
         hit_pts = 2
         hull_damage = 1260
         energy_damage = 1260
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -3549,7 +3549,7 @@
         hit_pts = 2
         hull_damage = 264.7
         energy_damage = 264.7
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser1
         munition_hit_effect = ci_laser_01_impact
         const_effect = bmod_gd_cv_light_blaster_01_projectile
@@ -3596,7 +3596,7 @@
         hit_pts = 2
         hull_damage = 115.24
         energy_damage = 115.24
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser1
         munition_hit_effect = ci_laser_01_impact
         const_effect = bmod_gd_cv_light_blaster_01_projectile
@@ -3643,7 +3643,7 @@
         hit_pts = 2
         hull_damage = 264.7
         energy_damage = 264.7
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser1
         munition_hit_effect = ci_laser_01_impact
         const_effect = bmod_gd_cv_light_blaster_01_projectile
@@ -3690,7 +3690,7 @@
         hit_pts = 2
         hull_damage = 264.7
         energy_damage = 264.7
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser1
         munition_hit_effect = ci_laser_01_impact
         const_effect = bmod_gd_cv_light_blaster_01_projectile
@@ -3737,7 +3737,7 @@
         hit_pts = 2
         hull_damage = 230.49
         energy_damage = 230.49
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser1
         munition_hit_effect = ci_laser_01_impact
         const_effect = bmod_gd_cv_light_blaster_01_projectile
@@ -3784,7 +3784,7 @@
         hit_pts = 2
         hull_damage = 264.7
         energy_damage = 264.7
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser1
         munition_hit_effect = ci_laser_01_impact
         const_effect = bmod_gd_cv_light_blaster_01_projectile
@@ -3831,7 +3831,7 @@
         hit_pts = 2
         hull_damage = 264.7
         energy_damage = 264.7
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser1
         munition_hit_effect = ci_laser_01_impact
         const_effect = bmod_gd_cv_light_blaster_01_projectile
@@ -3878,7 +3878,7 @@
         hit_pts = 2
         hull_damage = 345.7
         energy_damage = 345.7
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser1
         munition_hit_effect = ci_laser_01_impact
         const_effect = bmod_gd_cv_light_blaster_01_projectile
@@ -3925,7 +3925,7 @@
         hit_pts = 2
         hull_damage = 264.7
         energy_damage = 264.7
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser1
         munition_hit_effect = ci_laser_01_impact
         const_effect = bmod_gd_cv_light_blaster_01_projectile
@@ -3973,7 +3973,7 @@
         hit_pts = 2
         hull_damage = 446.25
         energy_damage = 446.25
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_laser_01
         munition_hit_effect = ci_laser_03_impact
         const_effect = bmod_gd_cv_heavy_blaster_01_projectile
@@ -4020,7 +4020,7 @@
         hit_pts = 2
         hull_damage = 200
         energy_damage = 200
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_laser_01
         munition_hit_effect = ci_laser_03_impact
         const_effect = bmod_gd_cv_heavy_blaster_01_projectile
@@ -4067,7 +4067,7 @@
         hit_pts = 2
         hull_damage = 446.25
         energy_damage = 446.25
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_laser_01
         munition_hit_effect = ci_laser_03_impact
         const_effect = bmod_gd_cv_heavy_blaster_01_projectile
@@ -4114,7 +4114,7 @@
         hit_pts = 2
         hull_damage = 446.25
         energy_damage = 446.25
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_laser_01
         munition_hit_effect = ci_laser_03_impact
         const_effect = bmod_gd_cv_heavy_blaster_01_projectile
@@ -4161,7 +4161,7 @@
         hit_pts = 2
         hull_damage = 400
         energy_damage = 400
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_laser_01
         munition_hit_effect = ci_laser_03_impact
         const_effect = bmod_gd_cv_heavy_blaster_01_projectile
@@ -4208,7 +4208,7 @@
         hit_pts = 2
         hull_damage = 446.25
         energy_damage = 446.25
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_laser_01
         munition_hit_effect = ci_laser_03_impact
         const_effect = bmod_gd_cv_heavy_blaster_01_projectile
@@ -4255,7 +4255,7 @@
         hit_pts = 2
         hull_damage = 446.25
         energy_damage = 446.25
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_laser_01
         munition_hit_effect = ci_laser_03_impact
         const_effect = bmod_gd_cv_heavy_blaster_01_projectile
@@ -4302,7 +4302,7 @@
         hit_pts = 2
         hull_damage = 600
         energy_damage = 600
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_laser_01
         munition_hit_effect = ci_laser_03_impact
         const_effect = bmod_gd_cv_heavy_blaster_01_projectile
@@ -4349,7 +4349,7 @@
         hit_pts = 2
         hull_damage = 446.25
         energy_damage = 446.25
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_laser_01
         munition_hit_effect = ci_laser_03_impact
         const_effect = bmod_gd_cv_heavy_blaster_01_projectile

--- a/DATA/EQUIPMENT/BMOD/bmod_equip_fleet_aux.ini
+++ b/DATA/EQUIPMENT/BMOD/bmod_equip_fleet_aux.ini
@@ -11,7 +11,7 @@
     hit_pts = 2
     hull_damage = -50
     energy_damage = 0
-    weapon_type = W_Plasma01
+    weapon_type = W_ENERGY01
     one_shot_sound = bmod_fire_repair_gun_fast
     munition_hit_effect = bmod_fleet_repair_gun_impact
     const_effect = bmod_fleet_repair_gun_projectile
@@ -62,7 +62,7 @@
     hit_pts = 2
     hull_damage = 2470
     energy_damage = 3087.5
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = bmod_l_laser
     munition_hit_effect = bmod_large_laser_impact
     const_effect = bmod_large_laser_proj
@@ -111,7 +111,7 @@
     hit_pts = 2
     hull_damage = 5000
     energy_damage = 5000
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = bmod_ppc
     munition_hit_effect = bmod_ppc_impact
     const_effect = bmod_ppc_fat_projectile
@@ -164,7 +164,7 @@
     hit_pts = 2
     hull_damage = 187.5
     energy_damage = 187.5
-    weapon_type = W_Plasma01
+    weapon_type = W_ENERGY01
     one_shot_sound = fire_ac2_01
     munition_hit_effect = li_laser_01_impact
     const_effect = bmod_ac2_01_proj_no_tracer
@@ -268,7 +268,7 @@
     hit_pts = 2
     hull_damage = 10000
     energy_damage = 5000
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = fire_ac20_01
     munition_hit_effect = bmod_ac20_impact
     const_effect = bmod_ac20_01_proj

--- a/DATA/EQUIPMENT/BMOD/bmod_equip_fleet_blaster.ini
+++ b/DATA/EQUIPMENT/BMOD/bmod_equip_fleet_blaster.ini
@@ -12,7 +12,7 @@
         hit_pts = 2
         hull_damage = 250
         energy_damage = 250
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = bmod_fire_mpulse01
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_02_projectile
@@ -59,7 +59,7 @@
         hit_pts = 2
         hull_damage = 250
         energy_damage = 250
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = bmod_fire_mpulse01
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_02_projectile
@@ -106,7 +106,7 @@
         hit_pts = 2
         hull_damage = 250
         energy_damage = 250
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = bmod_fire_mpulse01
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_02_projectile
@@ -154,7 +154,7 @@
         hit_pts = 2
         hull_damage = 360
         energy_damage = 360
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_fc_x_gun_heavy
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_01_projectile
@@ -201,7 +201,7 @@
         hit_pts = 2
         hull_damage = 360
         energy_damage = 360
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_fc_x_gun_heavy
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_01_projectile
@@ -248,7 +248,7 @@
         hit_pts = 2
         hull_damage = 360
         energy_damage = 360
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_fc_x_gun_heavy
         munition_hit_effect = bmod_fc_x_heavy_blaster_01_impact
         const_effect = bmod_fc_x_heavy_blaster_01_projectile
@@ -297,7 +297,7 @@
         hit_pts = 2
         hull_damage = 374.54
         energy_damage = 374.54
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_photon5
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_li_n_light_blaster_01_projectile
@@ -344,7 +344,7 @@
         hit_pts = 2
         hull_damage = 374.54
         energy_damage = 374.54
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_photon5
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_li_n_light_blaster_01_projectile
@@ -392,7 +392,7 @@
         hit_pts = 2
         hull_damage = 374.54
         energy_damage = 374.54
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_photon5
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_li_n_light_blaster_01_projectile
@@ -440,7 +440,7 @@
         hit_pts = 2
         hull_damage = 350
         energy_damage = 350
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -487,7 +487,7 @@
         hit_pts = 2
         hull_damage = 498.75
         energy_damage = 498.75
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -534,7 +534,7 @@
         hit_pts = 2
         hull_damage = 350
         energy_damage = 350
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -582,7 +582,7 @@
         hit_pts = 2
         hull_damage = 630
         energy_damage = 630
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_li_n_plasma01
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_01_projectile
@@ -629,7 +629,7 @@
         hit_pts = 2
         hull_damage = 892.5
         energy_damage = 892.5
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_li_n_plasma01
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_01_projectile
@@ -676,7 +676,7 @@
         hit_pts = 2
         hull_damage = 630
         energy_damage = 630
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_li_n_plasma01
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_01_projectile
@@ -725,7 +725,7 @@
         hit_pts = 2
         hull_damage = 787.5
         energy_damage = 787.5
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_particle1
         munition_hit_effect = pi_particle_01_impact
         const_effect = pi_particle_01_proj
@@ -772,7 +772,7 @@
         hit_pts = 2
         hull_damage = 787.5
         energy_damage = 787.5
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_particle1
         munition_hit_effect = pi_particle_01_impact
         const_effect = pi_particle_01_proj
@@ -819,7 +819,7 @@
         hit_pts = 2
         hull_damage = 787.5
         energy_damage = 787.5
-        weapon_type = W_Particle01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_particle1
         munition_hit_effect = pi_particle_01_impact
         const_effect = pi_particle_01_proj
@@ -867,7 +867,7 @@
         hit_pts = 2
         hull_damage = 980
         energy_damage = 980
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser5
         munition_hit_effect = pi_laser_01_impact
         const_effect = pi_laser_01_proj
@@ -914,7 +914,7 @@
         hit_pts = 2
         hull_damage = 980
         energy_damage = 980
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser5
         munition_hit_effect = pi_laser_01_impact
         const_effect = pi_laser_01_proj
@@ -961,7 +961,7 @@
         hit_pts = 2
         hull_damage = 980
         energy_damage = 980
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser5
         munition_hit_effect = pi_laser_01_impact
         const_effect = pi_laser_01_proj
@@ -1009,7 +1009,7 @@
         hit_pts = 2
         hull_damage = 1260
         energy_damage = 1260
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -1056,7 +1056,7 @@
         hit_pts = 2
         hull_damage = 1260
         energy_damage = 1260
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -1103,7 +1103,7 @@
         hit_pts = 2
         hull_damage = 1260
         energy_damage = 1260
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_bolt_med
         munition_hit_effect = pi_laser_02_impact
         const_effect = pi_laser_02_proj
@@ -1152,7 +1152,7 @@
         hit_pts = 2
         hull_damage = 264.7
         energy_damage = 264.7
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser1
         munition_hit_effect = ci_laser_01_impact
         const_effect = bmod_gd_cv_light_blaster_01_projectile
@@ -1199,7 +1199,7 @@
         hit_pts = 2
         hull_damage = 264.7
         energy_damage = 264.7
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser1
         munition_hit_effect = ci_laser_01_impact
         const_effect = bmod_gd_cv_light_blaster_01_projectile
@@ -1246,7 +1246,7 @@
         hit_pts = 2
         hull_damage = 264.7
         energy_damage = 264.7
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_laser1
         munition_hit_effect = ci_laser_01_impact
         const_effect = bmod_gd_cv_light_blaster_01_projectile
@@ -1294,7 +1294,7 @@
         hit_pts = 2
         hull_damage = 446.25
         energy_damage = 446.25
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_laser_01
         munition_hit_effect = ci_laser_03_impact
         const_effect = bmod_gd_cv_heavy_blaster_01_projectile
@@ -1341,7 +1341,7 @@
         hit_pts = 2
         hull_damage = 446.25
         energy_damage = 446.25
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_laser_01
         munition_hit_effect = ci_laser_03_impact
         const_effect = bmod_gd_cv_heavy_blaster_01_projectile
@@ -1388,7 +1388,7 @@
         hit_pts = 2
         hull_damage = 446.25
         energy_damage = 446.25
-        weapon_type = W_Laser01
+        weapon_type = W_ENERGY01
         one_shot_sound = beagle_laser_01
         munition_hit_effect = ci_laser_03_impact
         const_effect = bmod_gd_cv_heavy_blaster_01_projectile

--- a/DATA/EQUIPMENT/BMOD/bmod_equip_gear.ini
+++ b/DATA/EQUIPMENT/BMOD/bmod_equip_gear.ini
@@ -584,7 +584,7 @@
     hit_pts = 2
     hull_damage = 0
     energy_damage = 0
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     lifetime = 0.1
     force_gun_ori = true
     mass = 1
@@ -627,7 +627,7 @@
     hit_pts = 2
     hull_damage = 0
     energy_damage = 0
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     lifetime = 0.1
     force_gun_ori = true
     mass = 1

--- a/DATA/EQUIPMENT/BMOD/bmod_equip_npc.ini
+++ b/DATA/EQUIPMENT/BMOD/bmod_equip_npc.ini
@@ -98,7 +98,7 @@
     hull_damage = 10000
     energy_damage = 5000
     one_shot_sound = fire_ac20_01
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     munition_hit_effect = bmod_ac20_impact
     const_effect = bmod_ac20_01_proj
     lifetime = 5
@@ -273,7 +273,7 @@
     hit_pts = 2
     hull_damage = 2470
     energy_damage = 3087.5
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = bmod_l_laser
     munition_hit_effect = bmod_large_laser_impact
     const_effect = bmod_large_laser_proj
@@ -328,7 +328,7 @@
     hit_pts = 2
     hull_damage = 2470
     energy_damage = 3087.5
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = bmod_l_laser
     munition_hit_effect = bmod_large_laser_impact
     const_effect = bmod_large_laser_proj
@@ -377,7 +377,7 @@
     hit_pts = 2
     hull_damage = 5000
     energy_damage = 5000
-    weapon_type = W_Laser01
+    weapon_type = W_ENERGY01
     one_shot_sound = bmod_ppc
     munition_hit_effect = bmod_ppc_impact
     const_effect = bmod_ppc_fat_projectile
@@ -784,7 +784,7 @@
         hit_pts = 2
         hull_damage = 187.5
         energy_damage = 187.5
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_ac2_01
         munition_hit_effect = li_laser_01_impact
         const_effect = bmod_ac2_01_proj_no_tracer
@@ -1008,7 +1008,7 @@
         hit_pts = 2
         hull_damage = 220
         energy_damage = 220
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -1055,7 +1055,7 @@
         hit_pts = 2
         hull_damage = 440
         energy_damage = 440
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile
@@ -1102,7 +1102,7 @@
         hit_pts = 2
         hull_damage = 660
         energy_damage = 660
-        weapon_type = W_Plasma01
+        weapon_type = W_ENERGY01
         one_shot_sound = fire_plasma1
         munition_hit_effect = bmod_li_n_heavy_blaster_01_impact
         const_effect = bmod_li_n_heavy_blaster_02_projectile

--- a/DATA/EQUIPMENT/weaponmoddb.ini
+++ b/DATA/EQUIPMENT/weaponmoddb.ini
@@ -289,3 +289,15 @@ shield_mod = S_Molecular03, 0.05
 shield_mod = S_Positron01, 0.05
 shield_mod = S_Positron02, 0.05
 shield_mod = S_Positron03, 0.05
+
+[WeaponType]
+nickname = W_ENERGY01
+shield_mod = S_Graviton01, 1
+shield_mod = S_Graviton02, 1
+shield_mod = S_Graviton03, 1
+shield_mod = S_Molecular01, 1
+shield_mod = S_Molecular02, 1
+shield_mod = S_Molecular03, 1
+shield_mod = S_Positron01, 1
+shield_mod = S_Positron02, 1
+shield_mod = S_Positron03, 1


### PR DESCRIPTION
If we need to tune lasers and other energy weapons down the line, I would recommend we make new types in `weaponmoddb.ini`. For now, blasters, lasers, PPCs, etc are using a new generic type as part of our effort to phase out reused vanilla entries.